### PR TITLE
RDKB-60956: Default OAUTH AuthMode feature to SSO in firmware

### DIFF
--- a/source/Styles/xb3/jst/check.jst
+++ b/source/Styles/xb3/jst/check.jst
@@ -170,7 +170,17 @@ $clientIp = client_IP();
                 exit(0);
             }
             $authmode=getStr( "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.OAUTH.AuthMode" );
-            if( $authmode != "sso" )
+            if( $authmode == "sso" )
+            {
+                if (isset($_POST["password"]) && $_POST["password"] != "")
+                {
+                    LogStr(" : SSO FAILED ");
+                    session_destroy();
+                    sendError( '<script type="text/javascript"> alert($.i18n("SSO login rejected due to unexpected password input"));history.back(); </script>');
+                }
+                $curPwd1 = "Invalid_PWD"; // trigger SSO login attempt
+            }
+            else
             {
                 if( $authmode == "potd" || $_POST["password"] != "" )
                 {
@@ -189,10 +199,6 @@ $clientIp = client_IP();
                 {
                     $curPwd1 = "Invalid_PWD";    // trigger SSO login attempt
                 }
-            }
-            else
-            {
-                $curPwd1 = "Invalid_PWD";    // trigger SSO login attempt
             }
 	   // Allowing mso access only through CM IP , in case of CFG3 device CM IP is erouter0 IP.
            if ( ( (if_type($server_ip)=="rg_ip") && (strtolower($currentOpMode) !="ethernet") ) || (if_type($server_ip) =="lan_ip") || (($modelName == "CGA4131COM" || $modelName == "CGA4332COM") && (if_type($server_ip)=="remote_ip"))) 


### PR DESCRIPTION
Reason for change: Added failure case to avoid login for pwd entry in SSO mode
Test Procedure: As mentioned in the ticket
Risks: Medium