### PR TITLE
RDKB-61544: Default Start from Time is showing "PM"

### DIFF
--- a/source/Styles/xb3/jst/managed_sites.jst
+++ b/source/Styles/xb3/jst/managed_sites.jst
@@ -785,7 +785,7 @@ $.validator.addMethod("no_space", function(value, element, param) {
 
     $ID = $blockedInfo['InstanceID'];
    
-    $st_time = explode(":", $blockedInfo['StartTime']);	
+    $st_time = explode(":", $blockedInfo['StartTime']);
     $st_hour = $st_time['0'];
     $st_min  = isset($st_time['1'])? $st_time['1'] : "";
     $end_time = explode(":", $blockedInfo['EndTime']);
@@ -797,7 +797,8 @@ $.validator.addMethod("no_space", function(value, element, param) {
     if($blockedInfo['AlwaysBlock']=="true"){
     	$rel_st_hour = 12;
     	$st_min ="00";
-    	$rel_end_hour = 11;
+        $st_hour = 0;
+        $rel_end_hour = 11;
     	$end_min ="59";
     	$end_hour = 13;
     }


### PR DESCRIPTION
Reason for change: Default Start from Time is showing "PM" when Always-Block option Disabled

Test Procedure: Add Blocked Site/keyword with ALways block option

Risks:low
Priority: P1
Signed-off-by: pavankumarreddy_balireddy@comcast.com