### PR TITLE
RDK-61615: Remove Sensitive StringFrom Open Source

### DIFF
--- a/source/Styles/xb3/config/webgui.sh
+++ b/source/Styles/xb3/config/webgui.sh
@@ -54,7 +54,7 @@ if [ -d /nvram/certs ]; then
         exit 127
     fi
     mkdir -p /tmp/.webui/
-    ID="/tmp/trpfizyanrln"
+    ID="/tmp/myrouter-webui"
     GetConfigFile $ID
     cp /nvram/certs/myrouter.io.cert.pem /tmp/.webui/
     #lighttpd expects file with key and pem


### PR DESCRIPTION
Reason for change: Remove Sensitive String (pattern180) From Open Source
Test Procedure: Tested the tasks locally
Risks: Low
Signed-off-by: Aruna_Appikatla@comcast.com