### PR TITLE
XB10-2883 : [XB10-Commercial] WiFi edit page is broken

### DIFF
--- a/source/Styles/xb3/jst/actionHandler/ajaxSet_wireless_network_configuration_edit_onestack.jst
+++ b/source/Styles/xb3/jst/actionHandler/ajaxSet_wireless_network_configuration_edit_onestack.jst
@@ -351,5 +351,7 @@ if($response_message!='') {
 	$response.error_message = $response_message;
 	echo( htmlspecialchars(json_encode($response), ENT_NOQUOTES, 'UTF-8'));
 }
-else echo( htmlspecialchars($jsConfig, ENT_NOQUOTES, 'UTF-8'));
+else {
+	echo( htmlspecialchars(json_encode('success'), ENT_NOQUOTES, 'UTF-8'));
+}
 ?>

--- a/source/Styles/xb3/jst/wireless_network_configuration_edit_onestack.jst
+++ b/source/Styles/xb3/jst/wireless_network_configuration_edit_onestack.jst
@@ -665,14 +665,14 @@ $(document).ready(function() {
 			//40MHz
 			if ($("#channel_bandwidth1").is(":checked")) {
 				if ("BelowControlChannel" == "<?% echo( $ext_channel); ?>"){
-				$disableChannelList = [36, 44, 52, 60, 100, 108, 116, 132, 140, 144, 149, 157, 165 ];
-				checkAndSetChannelNumber($disableChannelList,'40');
-				$("#channel_number").trigger("change", {silent:true});
+					$disableChannelList = [36, 44, 52, 60, 100, 108, 116, 132, 140, 144, 149, 157, 165 ];
+					checkAndSetChannelNumber($disableChannelList,'40');
+				}
 				else{    //AboveControlChannel or Auto
 					$disableChannelList = [40, 48, 56, 64, 104, 112, 116, 136, 140, 144, 153, 161, 165 ];
 					checkAndSetChannelNumber($disableChannelList,'36');
-					$("#channel_number").trigger("change", {silent:true});
 				}
+				$("#channel_number").trigger("change", {silent:true});
 			}
 			//80MHz
 			else if ($("#channel_bandwidth2").is(":checked")) {


### PR DESCRIPTION
Reason for change: Fix a syntax error that breaks the WiFi edit page in XB10 Commercial builds.

Test Procedure: Open the WiFi edit page and verify the page loads correctly and edit actions work without syntax errors.

Risks: Low

Priority: P0