### PR TITLE
fix: XB10-2960 — 5GHz 160MHz channel bandwidth always disabled on page load

### DIFF
--- a/source/Styles/xb3/jst/wireless_network_configuration_onestack.jst
+++ b/source/Styles/xb3/jst/wireless_network_configuration_onestack.jst
@@ -643,7 +643,7 @@ $(document).ready(function() {
 		}else{
 			$("#channel_bandwidth3").prop("disabled", false);
 		}
-	}).trigger("change");
+	});
 
     $("[name='channel']").change(function() {
 		if($("#channel_automatic").is(":checked") || (MeshEnable=="true") || (HCMEnable == 'Enable')) {


### PR DESCRIPTION
## Summary
The **20/40/80/160** channel bandwidth radio button (`#channel_bandwidth3`) in the 5GHz wireless config page is permanently disabled on every page load, regardless of backend DFS state. All other options (20 / 20/40 / 20/40/80) work correctly.

## Affected Build
- **Model**: CGM601TCOM
- **Build**: `CGM601TCOM_DEV_26Q3_sprint_20260728232920sdy_NG` (SPIN 12)
- **File**: `source/Styles/xb3/jst/wireless_network_configuration_onestack.jst`

## Root Cause

```javascript
// BEFORE (broken)
$("[name='DFS_boot_disabled']").change(function() {
    if($("#DFS_boot_disabled").is(":checked"))  {
        $("#channel_bandwidth3").prop("disabled", true);
    }else{
        $("#channel_bandwidth3").prop("disabled", false);
    }
}).trigger("change");   // <-- BUG: fires on every page load
```

`.trigger("change")` unconditionally invokes the onChange handler at page load.  
Since `#DFS_boot_disabled` is HTML-default-checked (**Disable**), this **always** calls `.prop("disabled", true)` on `#channel_bandwidth3`, overriding the correct `$dfsBoot` backend-driven init block above it.

**Introduced by**: PR #37 — `RDKB-63519, RDKB-63615: 6GHz & XB10 models support in BWG GUI`  
**Commit**: `7b48cbac07` | **Merged**: 2026-02-26 | **Author**: Pavan Kumar Reddy B

## Fix

```javascript
// AFTER (fixed)
$("[name='DFS_boot_disabled']").change(function() {
    if($("#DFS_boot_disabled").is(":checked"))  {
        $("#channel_bandwidth3").prop("disabled", true);
    }else{
        $("#channel_bandwidth3").prop("disabled", false);
    }
});
// $dfsBoot static check above already handles initial page-load state from backend
```

Remove `.trigger("change")`. The `$dfsBoot='<?% echo($dfsAtBootup); ?>'` check immediately above already correctly sets initial disabled state from backend data — no trigger needed.

## Impact
- Only `#channel_bandwidth3` (160MHz) affected
- 100% reproducible on every page load on affected builds
- No backend / API changes required — JS-only, one-line fix

## Test
1. Navigate to **Wireless → 5GHz → Edit**
2. Verify 160MHz radio button is no longer greyed out
3. Toggle DFS Boot Disabled checkbox — verify 160MHz enables/disables correctly

Fixes: XB10-2960
