### PR TITLE
XB10-2997  6 GHz Radio details are missing in Hardware Page

### DIFF
--- a/source/Styles/xb3/jst/wifi.jst
+++ b/source/Styles/xb3/jst/wifi.jst
@@ -50,6 +50,12 @@ $wifi_param = {
 	"2_RadioUpTime"	: "Device.WiFi.Radio.2.X_COMCAST_COM_RadioUpTime" 
 	}/*p2j-array*/;
 $wifi_value = KeyExtGet("Device.WiFi.", $wifi_param);
+$wifi_6ghz = getStr("Device.WiFi.Radio.3.OperatingFrequencyBand") == "6GHz";
+if ($wifi_6ghz) {
+	$wifi_value['3_BSSID'] = getStr("Device.WiFi.SSID.17.BSSID");
+	$wifi_value['3_Status'] = getStr("Device.WiFi.SSID.17.Status");
+	$wifi_value['3_RadioUpTime'] = getStr("Device.WiFi.Radio.3.X_COMCAST_COM_RadioUpTime");
+}
 
 //wrap for PSM mode
 if ("Enabled" == $_SESSION["psmMode"])
@@ -58,10 +64,12 @@ if ("Enabled" == $_SESSION["psmMode"])
 	$wifi_value['1_BSSID']	="";
 	$wifi_value['2_Enable']	="";
 	$wifi_value['2_BSSID']	="";
+	$wifi_value['3_BSSID']	="";
 }
 
 $wifi_status1 = ($wifi_value['1_Status'] == 'Up') ? true : false ;
 $wifi_status2 = ($wifi_value['2_Status'] == 'Up') ? true : false ;
+$wifi_status3 = $wifi_6ghz && ($wifi_value['3_Status'] == 'Up');
 
 function div_mod($n, $m)
 {
@@ -135,6 +143,35 @@ function div_mod($n, $m)
 		</span>
 		</div>
 	</div> <!-- end .module -->
+
+	<?% if($wifi_6ghz) { ?>
+	<div class="module forms block">
+		<h2>Wi-Fi LAN port (6 GHz)</h2>
+		<div class="form-row">
+			<span class="readonlyLabel">Wi-Fi link status:</span>
+			<span class="value"><?% echo( ($wifi_status3)?"Active":"Inactive");?></span>
+		</div>
+		<div class="form-row odd">
+			<span class="readonlyLabel">MAC Address:</span>
+			<span class="value"><?% echo( $wifi_value['3_BSSID']);?></span>
+		</div>
+		<div class="form-row">
+			<span class="readonlyLabel">System Uptime:</span>
+			<span class="value">
+			<?%
+			$sec = ($wifi_status3)?$wifi_value['3_RadioUpTime']:0;
+			$tmp = div_mod($sec, 24*60*60);
+			$day = $tmp[0];
+			$tmp = div_mod($tmp[1], 60*60);
+			$hor = $tmp[0];
+			$tmp = div_mod($tmp[1],    60);
+			$min = $tmp[0];
+			echo( $day+" days "+$hor+"h: "+$min+"m: "+$tmp[1]+"s");
+		?>
+		</span>
+		</div>
+	</div> <!-- end .module -->
+	<?% } ?>
 
 	<!--<div class="module forms block">
 		<h2>DECT Base</h2>


### PR DESCRIPTION
Reason for change: Display the 6 GHz radio status, MAC address, and uptime when Radio 3 reports the 6GHz frequency band in Hardware Page
Test Procedure: Test for 6 GHz radio status, MAC address, and uptime
Risks: Low
Priority: P1